### PR TITLE
EG-2784 Adds support for prefix parsing on grouped expressions

### DIFF
--- a/lib/lucene.grammar
+++ b/lib/lucene.grammar
@@ -143,9 +143,17 @@ node
     }
 
 group_exp
-  = field_exp:field_exp _*
+  = prefix_field_exp:prefix_field_exp _*
     {
-        return field_exp;
+        return prefix_field_exp;
+    }
+  / prefix_paren_exp
+
+prefix_paren_exp
+  = prefix:prefix_operator_exp _* paren:paren_exp
+    {
+        paren['group_prefix'] = prefix;
+        return paren;
     }
   / paren_exp
 
@@ -155,6 +163,42 @@ paren_exp
         node[0]['parenthesized'] = true;
         return node[0];
     }
+
+prefix_field_exp
+  = prefix:prefix_operator_exp _* fieldname:fieldname? range:range_operator_exp
+    {
+        range['field'] =
+            fieldname == '' || fieldname == null
+                ? "<implicit>"
+                : fieldname;
+        range['group_prefix'] = prefix;
+
+        return range;
+    }
+  / prefix:prefix_operator_exp _* fieldname:fieldname node:paren_exp
+    {
+        node['field']= fieldname;
+        node['group_prefix']= prefix;
+        return node;
+    }
+  / prefix:prefix_operator_exp _* fieldname:fieldname term:term
+    {
+        var fieldexp = {
+            'field':
+                fieldname == '' || fieldname == null
+                    ? "<implicit>"
+                    : fieldname
+            };
+
+        for(var key in term)
+            fieldexp[key] = term[key];
+
+        fieldexp['group_prefix'] = prefix;
+
+        return fieldexp;
+    }
+   / field_exp
+
 
 field_exp
 

--- a/lib/queryParser.js
+++ b/lib/queryParser.js
@@ -87,19 +87,52 @@ module.exports = (function() {
 
                 return node;
             },
-        peg$c8 = function(field_exp) {
-                return field_exp;
+        peg$c8 = function(prefix_field_exp) {
+                return prefix_field_exp;
             },
-        peg$c9 = "(",
-        peg$c10 = { type: "literal", value: "(", description: "\"(\"" },
-        peg$c11 = ")",
-        peg$c12 = { type: "literal", value: ")", description: "\")\"" },
-        peg$c13 = function(node) {
+        peg$c9 = function(prefix, paren) {
+                paren['group_prefix'] = prefix;
+                return paren;
+            },
+        peg$c10 = "(",
+        peg$c11 = { type: "literal", value: "(", description: "\"(\"" },
+        peg$c12 = ")",
+        peg$c13 = { type: "literal", value: ")", description: "\")\"" },
+        peg$c14 = function(node) {
                 node[0]['parenthesized'] = true;
                 return node[0];
             },
-        peg$c14 = null,
-        peg$c15 = function(fieldname, range) {
+        peg$c15 = null,
+        peg$c16 = function(prefix, fieldname, range) {
+                range['field'] =
+                    fieldname == '' || fieldname == null
+                        ? "<implicit>"
+                        : fieldname;
+                range['group_prefix'] = prefix;
+
+                return range;
+            },
+        peg$c17 = function(prefix, fieldname, node) {
+                node['field']= fieldname;
+                node['group_prefix']= prefix;
+                return node;
+            },
+        peg$c18 = function(prefix, fieldname, term) {
+                var fieldexp = {
+                    'field':
+                        fieldname == '' || fieldname == null
+                            ? "<implicit>"
+                            : fieldname
+                    };
+
+                for(var key in term)
+                    fieldexp[key] = term[key];
+
+                fieldexp['group_prefix'] = prefix;
+
+                return fieldexp;
+            },
+        peg$c19 = function(fieldname, range) {
                 range['field'] =
                     fieldname == '' || fieldname == null
                         ? "<implicit>"
@@ -107,11 +140,11 @@ module.exports = (function() {
 
                 return range;
             },
-        peg$c16 = function(fieldname, node) {
+        peg$c20 = function(fieldname, node) {
                 node['field']= fieldname;
                 return node;
             },
-        peg$c17 = function(fieldname, term) {
+        peg$c21 = function(fieldname, term) {
                 var fieldexp = {
                     'field':
                         fieldname == '' || fieldname == null
@@ -124,12 +157,12 @@ module.exports = (function() {
 
                 return fieldexp;
             },
-        peg$c18 = /^[:]/,
-        peg$c19 = { type: "class", value: "[:]", description: "[:]" },
-        peg$c20 = function(fieldname) {
+        peg$c22 = /^[:]/,
+        peg$c23 = { type: "class", value: "[:]", description: "[:]" },
+        peg$c24 = function(fieldname) {
                 return fieldname;
             },
-        peg$c21 = function(op, term, proximity, boost) {
+        peg$c25 = function(op, term, proximity, boost) {
                 var result = {
                   'term': term,
                   'quoted': true
@@ -150,7 +183,7 @@ module.exports = (function() {
 
                 return result;
             },
-        peg$c22 = function(op, term, similarity, boost) {
+        peg$c26 = function(op, term, similarity, boost) {
                 var result = {
                   'term': term,
                   'quoted': false
@@ -169,123 +202,123 @@ module.exports = (function() {
                 }
                 return result;
             },
-        peg$c23 = ".",
-        peg$c24 = { type: "literal", value: ".", description: "\".\"" },
-        peg$c25 = /^[^ \t\r\n\f{}()"\/\^~[\]]/,
-        peg$c26 = { type: "class", value: "[^ \\t\\r\\n\\f{}()\"\\/\\^~[\\]]", description: "[^ \\t\\r\\n\\f{}()\"\\/\\^~[\\]]" },
-        peg$c27 = function(term) {
+        peg$c27 = ".",
+        peg$c28 = { type: "literal", value: ".", description: "\".\"" },
+        peg$c29 = /^[^ \t\r\n\f{}()"\/\^~[\]]/,
+        peg$c30 = { type: "class", value: "[^ \\t\\r\\n\\f{}()\"\\/\\^~[\\]]", description: "[^ \\t\\r\\n\\f{}()\"\\/\\^~[\\]]" },
+        peg$c31 = function(term) {
                 return term.join('');
             },
-        peg$c28 = /^[^: \t\r\n\f{}()"\/\^[\]]/,
-        peg$c29 = { type: "class", value: "[^: \\t\\r\\n\\f{}()\"\\/\\^[\\]]", description: "[^: \\t\\r\\n\\f{}()\"\\/\\^[\\]]" },
-        peg$c30 = "\"",
-        peg$c31 = { type: "literal", value: "\"", description: "\"\\\"\"" },
-        peg$c32 = function(chars) { return chars.join(''); },
-        peg$c33 = void 0,
-        peg$c34 = "\\",
-        peg$c35 = { type: "literal", value: "\\", description: "\"\\\\\"" },
-        peg$c36 = { type: "any", description: "any character" },
-        peg$c37 = function(char) { return char; },
-        peg$c38 = function(sequence) { return sequence; },
-        peg$c39 = "+",
-        peg$c40 = { type: "literal", value: "+", description: "\"+\"" },
-        peg$c41 = "-",
-        peg$c42 = { type: "literal", value: "-", description: "\"-\"" },
-        peg$c43 = "!",
-        peg$c44 = { type: "literal", value: "!", description: "\"!\"" },
-        peg$c45 = "{",
-        peg$c46 = { type: "literal", value: "{", description: "\"{\"" },
-        peg$c47 = "}",
-        peg$c48 = { type: "literal", value: "}", description: "\"}\"" },
-        peg$c49 = "[",
-        peg$c50 = { type: "literal", value: "[", description: "\"[\"" },
-        peg$c51 = "]",
-        peg$c52 = { type: "literal", value: "]", description: "\"]\"" },
-        peg$c53 = "^",
-        peg$c54 = { type: "literal", value: "^", description: "\"^\"" },
-        peg$c55 = "?",
-        peg$c56 = { type: "literal", value: "?", description: "\"?\"" },
-        peg$c57 = ":",
-        peg$c58 = { type: "literal", value: ":", description: "\":\"" },
-        peg$c59 = "&",
-        peg$c60 = { type: "literal", value: "&", description: "\"&\"" },
-        peg$c61 = "|",
-        peg$c62 = { type: "literal", value: "|", description: "\"|\"" },
-        peg$c63 = "'",
-        peg$c64 = { type: "literal", value: "'", description: "\"'\"" },
-        peg$c65 = "/",
-        peg$c66 = { type: "literal", value: "/", description: "\"/\"" },
-        peg$c67 = "~",
-        peg$c68 = { type: "literal", value: "~", description: "\"~\"" },
-        peg$c69 = function(proximity) {
+        peg$c32 = /^[^: \t\r\n\f{}()"\/\^[\]]/,
+        peg$c33 = { type: "class", value: "[^: \\t\\r\\n\\f{}()\"\\/\\^[\\]]", description: "[^: \\t\\r\\n\\f{}()\"\\/\\^[\\]]" },
+        peg$c34 = "\"",
+        peg$c35 = { type: "literal", value: "\"", description: "\"\\\"\"" },
+        peg$c36 = function(chars) { return chars.join(''); },
+        peg$c37 = void 0,
+        peg$c38 = "\\",
+        peg$c39 = { type: "literal", value: "\\", description: "\"\\\\\"" },
+        peg$c40 = { type: "any", description: "any character" },
+        peg$c41 = function(char) { return char; },
+        peg$c42 = function(sequence) { return sequence; },
+        peg$c43 = "+",
+        peg$c44 = { type: "literal", value: "+", description: "\"+\"" },
+        peg$c45 = "-",
+        peg$c46 = { type: "literal", value: "-", description: "\"-\"" },
+        peg$c47 = "!",
+        peg$c48 = { type: "literal", value: "!", description: "\"!\"" },
+        peg$c49 = "{",
+        peg$c50 = { type: "literal", value: "{", description: "\"{\"" },
+        peg$c51 = "}",
+        peg$c52 = { type: "literal", value: "}", description: "\"}\"" },
+        peg$c53 = "[",
+        peg$c54 = { type: "literal", value: "[", description: "\"[\"" },
+        peg$c55 = "]",
+        peg$c56 = { type: "literal", value: "]", description: "\"]\"" },
+        peg$c57 = "^",
+        peg$c58 = { type: "literal", value: "^", description: "\"^\"" },
+        peg$c59 = "?",
+        peg$c60 = { type: "literal", value: "?", description: "\"?\"" },
+        peg$c61 = ":",
+        peg$c62 = { type: "literal", value: ":", description: "\":\"" },
+        peg$c63 = "&",
+        peg$c64 = { type: "literal", value: "&", description: "\"&\"" },
+        peg$c65 = "|",
+        peg$c66 = { type: "literal", value: "|", description: "\"|\"" },
+        peg$c67 = "'",
+        peg$c68 = { type: "literal", value: "'", description: "\"'\"" },
+        peg$c69 = "/",
+        peg$c70 = { type: "literal", value: "/", description: "\"/\"" },
+        peg$c71 = "~",
+        peg$c72 = { type: "literal", value: "~", description: "\"~\"" },
+        peg$c73 = function(proximity) {
                 return proximity;
             },
-        peg$c70 = function(boost) {
+        peg$c74 = function(boost) {
                 return boost;
             },
-        peg$c71 = function(fuzziness) {
+        peg$c75 = function(fuzziness) {
                 return fuzziness == '' || fuzziness == null ? 0.5 : fuzziness;
             },
-        peg$c72 = "0.",
-        peg$c73 = { type: "literal", value: "0.", description: "\"0.\"" },
-        peg$c74 = /^[0-9]/,
-        peg$c75 = { type: "class", value: "[0-9]", description: "[0-9]" },
-        peg$c76 = function(val) {
+        peg$c76 = "0.",
+        peg$c77 = { type: "literal", value: "0.", description: "\"0.\"" },
+        peg$c78 = /^[0-9]/,
+        peg$c79 = { type: "class", value: "[0-9]", description: "[0-9]" },
+        peg$c80 = function(val) {
                 return parseFloat("0." + val.join(''));
             },
-        peg$c77 = function(val) {
+        peg$c81 = function(val) {
                 return parseInt(val.join(''));
             },
-        peg$c78 = "TO",
-        peg$c79 = { type: "literal", value: "TO", description: "\"TO\"" },
-        peg$c80 = function(term_min, term_max) {
+        peg$c82 = "TO",
+        peg$c83 = { type: "literal", value: "TO", description: "\"TO\"" },
+        peg$c84 = function(term_min, term_max) {
                 return {
                     'term_min': term_min,
                     'term_max': term_max,
                     'inclusive': 'both'
                 };
             },
-        peg$c81 = function(term_min, term_max) {
+        peg$c85 = function(term_min, term_max) {
                 return {
                     'term_min': term_min,
                     'term_max': term_max,
                     'inclusive': 'none'
                 };
             },
-        peg$c82 = function(term_min, term_max) {
+        peg$c86 = function(term_min, term_max) {
                 return {
                     'term_min': term_min,
                     'term_max': term_max,
                     'inclusive': 'left'
                 };
             },
-        peg$c83 = function(term_min, term_max) {
+        peg$c87 = function(term_min, term_max) {
                 return {
                     'term_min': term_min,
                     'term_max': term_max,
                     'inclusive': 'right'
                 };
             },
-        peg$c84 = function(operator) {
+        peg$c88 = function(operator) {
                 return operator;
             },
-        peg$c85 = "OR NOT",
-        peg$c86 = { type: "literal", value: "OR NOT", description: "\"OR NOT\"" },
-        peg$c87 = "AND NOT",
-        peg$c88 = { type: "literal", value: "AND NOT", description: "\"AND NOT\"" },
-        peg$c89 = "OR",
-        peg$c90 = { type: "literal", value: "OR", description: "\"OR\"" },
-        peg$c91 = "AND",
-        peg$c92 = { type: "literal", value: "AND", description: "\"AND\"" },
-        peg$c93 = "NOT",
-        peg$c94 = { type: "literal", value: "NOT", description: "\"NOT\"" },
-        peg$c95 = "||",
-        peg$c96 = { type: "literal", value: "||", description: "\"||\"" },
-        peg$c97 = "&&",
-        peg$c98 = { type: "literal", value: "&&", description: "\"&&\"" },
-        peg$c99 = { type: "other", description: "whitespace" },
-        peg$c100 = /^[ \t\r\n\f]/,
-        peg$c101 = { type: "class", value: "[ \\t\\r\\n\\f]", description: "[ \\t\\r\\n\\f]" },
+        peg$c89 = "OR NOT",
+        peg$c90 = { type: "literal", value: "OR NOT", description: "\"OR NOT\"" },
+        peg$c91 = "AND NOT",
+        peg$c92 = { type: "literal", value: "AND NOT", description: "\"AND NOT\"" },
+        peg$c93 = "OR",
+        peg$c94 = { type: "literal", value: "OR", description: "\"OR\"" },
+        peg$c95 = "AND",
+        peg$c96 = { type: "literal", value: "AND", description: "\"AND\"" },
+        peg$c97 = "NOT",
+        peg$c98 = { type: "literal", value: "NOT", description: "\"NOT\"" },
+        peg$c99 = "||",
+        peg$c100 = { type: "literal", value: "||", description: "\"||\"" },
+        peg$c101 = "&&",
+        peg$c102 = { type: "literal", value: "&&", description: "\"&&\"" },
+        peg$c103 = { type: "other", description: "whitespace" },
+        peg$c104 = /^[ \t\r\n\f]/,
+        peg$c105 = { type: "class", value: "[ \\t\\r\\n\\f]", description: "[ \\t\\r\\n\\f]" },
 
         peg$currPos          = 0,
         peg$reportedPos      = 0,
@@ -632,7 +665,7 @@ module.exports = (function() {
       var s0, s1, s2, s3;
 
       s0 = peg$currPos;
-      s1 = peg$parsefield_exp();
+      s1 = peg$parseprefix_field_exp();
       if (s1 !== peg$FAILED) {
         s2 = [];
         s3 = peg$parse_();
@@ -653,6 +686,43 @@ module.exports = (function() {
         s0 = peg$c0;
       }
       if (s0 === peg$FAILED) {
+        s0 = peg$parseprefix_paren_exp();
+      }
+
+      return s0;
+    }
+
+    function peg$parseprefix_paren_exp() {
+      var s0, s1, s2, s3;
+
+      s0 = peg$currPos;
+      s1 = peg$parseprefix_operator_exp();
+      if (s1 !== peg$FAILED) {
+        s2 = [];
+        s3 = peg$parse_();
+        while (s3 !== peg$FAILED) {
+          s2.push(s3);
+          s3 = peg$parse_();
+        }
+        if (s2 !== peg$FAILED) {
+          s3 = peg$parseparen_exp();
+          if (s3 !== peg$FAILED) {
+            peg$reportedPos = s0;
+            s1 = peg$c9(s1, s3);
+            s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$c0;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$c0;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$c0;
+      }
+      if (s0 === peg$FAILED) {
         s0 = peg$parseparen_exp();
       }
 
@@ -664,11 +734,11 @@ module.exports = (function() {
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 40) {
-        s1 = peg$c9;
+        s1 = peg$c10;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c10); }
+        if (peg$silentFails === 0) { peg$fail(peg$c11); }
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
@@ -683,11 +753,11 @@ module.exports = (function() {
         }
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 41) {
-            s3 = peg$c11;
+            s3 = peg$c12;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c12); }
+            if (peg$silentFails === 0) { peg$fail(peg$c13); }
           }
           if (s3 !== peg$FAILED) {
             s4 = [];
@@ -698,7 +768,7 @@ module.exports = (function() {
             }
             if (s4 !== peg$FAILED) {
               peg$reportedPos = s0;
-              s1 = peg$c13(s2);
+              s1 = peg$c14(s2);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -720,19 +790,135 @@ module.exports = (function() {
       return s0;
     }
 
+    function peg$parseprefix_field_exp() {
+      var s0, s1, s2, s3, s4;
+
+      s0 = peg$currPos;
+      s1 = peg$parseprefix_operator_exp();
+      if (s1 !== peg$FAILED) {
+        s2 = [];
+        s3 = peg$parse_();
+        while (s3 !== peg$FAILED) {
+          s2.push(s3);
+          s3 = peg$parse_();
+        }
+        if (s2 !== peg$FAILED) {
+          s3 = peg$parsefieldname();
+          if (s3 === peg$FAILED) {
+            s3 = peg$c15;
+          }
+          if (s3 !== peg$FAILED) {
+            s4 = peg$parserange_operator_exp();
+            if (s4 !== peg$FAILED) {
+              peg$reportedPos = s0;
+              s1 = peg$c16(s1, s3, s4);
+              s0 = s1;
+            } else {
+              peg$currPos = s0;
+              s0 = peg$c0;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$c0;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$c0;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$c0;
+      }
+      if (s0 === peg$FAILED) {
+        s0 = peg$currPos;
+        s1 = peg$parseprefix_operator_exp();
+        if (s1 !== peg$FAILED) {
+          s2 = [];
+          s3 = peg$parse_();
+          while (s3 !== peg$FAILED) {
+            s2.push(s3);
+            s3 = peg$parse_();
+          }
+          if (s2 !== peg$FAILED) {
+            s3 = peg$parsefieldname();
+            if (s3 !== peg$FAILED) {
+              s4 = peg$parseparen_exp();
+              if (s4 !== peg$FAILED) {
+                peg$reportedPos = s0;
+                s1 = peg$c17(s1, s3, s4);
+                s0 = s1;
+              } else {
+                peg$currPos = s0;
+                s0 = peg$c0;
+              }
+            } else {
+              peg$currPos = s0;
+              s0 = peg$c0;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$c0;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$c0;
+        }
+        if (s0 === peg$FAILED) {
+          s0 = peg$currPos;
+          s1 = peg$parseprefix_operator_exp();
+          if (s1 !== peg$FAILED) {
+            s2 = [];
+            s3 = peg$parse_();
+            while (s3 !== peg$FAILED) {
+              s2.push(s3);
+              s3 = peg$parse_();
+            }
+            if (s2 !== peg$FAILED) {
+              s3 = peg$parsefieldname();
+              if (s3 !== peg$FAILED) {
+                s4 = peg$parseterm();
+                if (s4 !== peg$FAILED) {
+                  peg$reportedPos = s0;
+                  s1 = peg$c18(s1, s3, s4);
+                  s0 = s1;
+                } else {
+                  peg$currPos = s0;
+                  s0 = peg$c0;
+                }
+              } else {
+                peg$currPos = s0;
+                s0 = peg$c0;
+              }
+            } else {
+              peg$currPos = s0;
+              s0 = peg$c0;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$c0;
+          }
+          if (s0 === peg$FAILED) {
+            s0 = peg$parsefield_exp();
+          }
+        }
+      }
+
+      return s0;
+    }
+
     function peg$parsefield_exp() {
       var s0, s1, s2;
 
       s0 = peg$currPos;
       s1 = peg$parsefieldname();
       if (s1 === peg$FAILED) {
-        s1 = peg$c14;
+        s1 = peg$c15;
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parserange_operator_exp();
         if (s2 !== peg$FAILED) {
           peg$reportedPos = s0;
-          s1 = peg$c15(s1, s2);
+          s1 = peg$c19(s1, s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -749,7 +935,7 @@ module.exports = (function() {
           s2 = peg$parseparen_exp();
           if (s2 !== peg$FAILED) {
             peg$reportedPos = s0;
-            s1 = peg$c16(s1, s2);
+            s1 = peg$c20(s1, s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -763,13 +949,13 @@ module.exports = (function() {
           s0 = peg$currPos;
           s1 = peg$parsefieldname();
           if (s1 === peg$FAILED) {
-            s1 = peg$c14;
+            s1 = peg$c15;
           }
           if (s1 !== peg$FAILED) {
             s2 = peg$parseterm();
             if (s2 !== peg$FAILED) {
               peg$reportedPos = s0;
-              s1 = peg$c17(s1, s2);
+              s1 = peg$c21(s1, s2);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -791,16 +977,16 @@ module.exports = (function() {
       s0 = peg$currPos;
       s1 = peg$parseunquoted_term();
       if (s1 !== peg$FAILED) {
-        if (peg$c18.test(input.charAt(peg$currPos))) {
+        if (peg$c22.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c19); }
+          if (peg$silentFails === 0) { peg$fail(peg$c23); }
         }
         if (s2 !== peg$FAILED) {
           peg$reportedPos = s0;
-          s1 = peg$c20(s1);
+          s1 = peg$c24(s1);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -820,19 +1006,19 @@ module.exports = (function() {
       s0 = peg$currPos;
       s1 = peg$parseprefix_operator_exp();
       if (s1 === peg$FAILED) {
-        s1 = peg$c14;
+        s1 = peg$c15;
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parsequoted_term();
         if (s2 !== peg$FAILED) {
           s3 = peg$parseproximity_modifier();
           if (s3 === peg$FAILED) {
-            s3 = peg$c14;
+            s3 = peg$c15;
           }
           if (s3 !== peg$FAILED) {
             s4 = peg$parseboost_modifier();
             if (s4 === peg$FAILED) {
-              s4 = peg$c14;
+              s4 = peg$c15;
             }
             if (s4 !== peg$FAILED) {
               s5 = [];
@@ -843,7 +1029,7 @@ module.exports = (function() {
               }
               if (s5 !== peg$FAILED) {
                 peg$reportedPos = s0;
-                s1 = peg$c21(s1, s2, s3, s4);
+                s1 = peg$c25(s1, s2, s3, s4);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -869,19 +1055,19 @@ module.exports = (function() {
         s0 = peg$currPos;
         s1 = peg$parseprefix_operator_exp();
         if (s1 === peg$FAILED) {
-          s1 = peg$c14;
+          s1 = peg$c15;
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parseunquoted_term();
           if (s2 !== peg$FAILED) {
             s3 = peg$parsefuzzy_modifier();
             if (s3 === peg$FAILED) {
-              s3 = peg$c14;
+              s3 = peg$c15;
             }
             if (s3 !== peg$FAILED) {
               s4 = peg$parseboost_modifier();
               if (s4 === peg$FAILED) {
-                s4 = peg$c14;
+                s4 = peg$c15;
               }
               if (s4 !== peg$FAILED) {
                 s5 = [];
@@ -892,7 +1078,7 @@ module.exports = (function() {
                 }
                 if (s5 !== peg$FAILED) {
                   peg$reportedPos = s0;
-                  s1 = peg$c22(s1, s2, s3, s4);
+                  s1 = peg$c26(s1, s2, s3, s4);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -923,19 +1109,19 @@ module.exports = (function() {
       var s0;
 
       if (input.charCodeAt(peg$currPos) === 46) {
-        s0 = peg$c23;
+        s0 = peg$c27;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c24); }
+        if (peg$silentFails === 0) { peg$fail(peg$c28); }
       }
       if (s0 === peg$FAILED) {
-        if (peg$c25.test(input.charAt(peg$currPos))) {
+        if (peg$c29.test(input.charAt(peg$currPos))) {
           s0 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c26); }
+          if (peg$silentFails === 0) { peg$fail(peg$c30); }
         }
       }
 
@@ -958,7 +1144,7 @@ module.exports = (function() {
       }
       if (s1 !== peg$FAILED) {
         peg$reportedPos = s0;
-        s1 = peg$c27(s1);
+        s1 = peg$c31(s1);
       }
       s0 = s1;
 
@@ -981,7 +1167,7 @@ module.exports = (function() {
       }
       if (s1 !== peg$FAILED) {
         peg$reportedPos = s0;
-        s1 = peg$c27(s1);
+        s1 = peg$c31(s1);
       }
       s0 = s1;
 
@@ -992,19 +1178,19 @@ module.exports = (function() {
       var s0;
 
       if (input.charCodeAt(peg$currPos) === 46) {
-        s0 = peg$c23;
+        s0 = peg$c27;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c24); }
+        if (peg$silentFails === 0) { peg$fail(peg$c28); }
       }
       if (s0 === peg$FAILED) {
-        if (peg$c28.test(input.charAt(peg$currPos))) {
+        if (peg$c32.test(input.charAt(peg$currPos))) {
           s0 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c29); }
+          if (peg$silentFails === 0) { peg$fail(peg$c33); }
         }
       }
 
@@ -1016,11 +1202,11 @@ module.exports = (function() {
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 34) {
-        s1 = peg$c30;
+        s1 = peg$c34;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c31); }
+        if (peg$silentFails === 0) { peg$fail(peg$c35); }
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
@@ -1031,15 +1217,15 @@ module.exports = (function() {
         }
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 34) {
-            s3 = peg$c30;
+            s3 = peg$c34;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c31); }
+            if (peg$silentFails === 0) { peg$fail(peg$c35); }
           }
           if (s3 !== peg$FAILED) {
             peg$reportedPos = s0;
-            s1 = peg$c32(s2);
+            s1 = peg$c36(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -1064,24 +1250,24 @@ module.exports = (function() {
       s1 = peg$currPos;
       peg$silentFails++;
       if (input.charCodeAt(peg$currPos) === 34) {
-        s2 = peg$c30;
+        s2 = peg$c34;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c31); }
+        if (peg$silentFails === 0) { peg$fail(peg$c35); }
       }
       if (s2 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 92) {
-          s2 = peg$c34;
+          s2 = peg$c38;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c35); }
+          if (peg$silentFails === 0) { peg$fail(peg$c39); }
         }
       }
       peg$silentFails--;
       if (s2 === peg$FAILED) {
-        s1 = peg$c33;
+        s1 = peg$c37;
       } else {
         peg$currPos = s1;
         s1 = peg$c0;
@@ -1092,11 +1278,11 @@ module.exports = (function() {
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c36); }
+          if (peg$silentFails === 0) { peg$fail(peg$c40); }
         }
         if (s2 !== peg$FAILED) {
           peg$reportedPos = s0;
-          s1 = peg$c37(s2);
+          s1 = peg$c41(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -1109,17 +1295,17 @@ module.exports = (function() {
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 92) {
-          s1 = peg$c34;
+          s1 = peg$c38;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c35); }
+          if (peg$silentFails === 0) { peg$fail(peg$c39); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parseEscapeSequence();
           if (s2 !== peg$FAILED) {
             peg$reportedPos = s0;
-            s1 = peg$c38(s2);
+            s1 = peg$c42(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -1138,147 +1324,147 @@ module.exports = (function() {
       var s0;
 
       if (input.charCodeAt(peg$currPos) === 43) {
-        s0 = peg$c39;
+        s0 = peg$c43;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c40); }
+        if (peg$silentFails === 0) { peg$fail(peg$c44); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 45) {
-          s0 = peg$c41;
+          s0 = peg$c45;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c42); }
+          if (peg$silentFails === 0) { peg$fail(peg$c46); }
         }
         if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 33) {
-            s0 = peg$c43;
+            s0 = peg$c47;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c44); }
+            if (peg$silentFails === 0) { peg$fail(peg$c48); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 40) {
-              s0 = peg$c9;
+              s0 = peg$c10;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c10); }
+              if (peg$silentFails === 0) { peg$fail(peg$c11); }
             }
             if (s0 === peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 41) {
-                s0 = peg$c11;
+                s0 = peg$c12;
                 peg$currPos++;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c12); }
+                if (peg$silentFails === 0) { peg$fail(peg$c13); }
               }
               if (s0 === peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 123) {
-                  s0 = peg$c45;
+                  s0 = peg$c49;
                   peg$currPos++;
                 } else {
                   s0 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c46); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c50); }
                 }
                 if (s0 === peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 125) {
-                    s0 = peg$c47;
+                    s0 = peg$c51;
                     peg$currPos++;
                   } else {
                     s0 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c48); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c52); }
                   }
                   if (s0 === peg$FAILED) {
                     if (input.charCodeAt(peg$currPos) === 91) {
-                      s0 = peg$c49;
+                      s0 = peg$c53;
                       peg$currPos++;
                     } else {
                       s0 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c50); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c54); }
                     }
                     if (s0 === peg$FAILED) {
                       if (input.charCodeAt(peg$currPos) === 93) {
-                        s0 = peg$c51;
+                        s0 = peg$c55;
                         peg$currPos++;
                       } else {
                         s0 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c52); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c56); }
                       }
                       if (s0 === peg$FAILED) {
                         if (input.charCodeAt(peg$currPos) === 94) {
-                          s0 = peg$c53;
+                          s0 = peg$c57;
                           peg$currPos++;
                         } else {
                           s0 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c54); }
+                          if (peg$silentFails === 0) { peg$fail(peg$c58); }
                         }
                         if (s0 === peg$FAILED) {
                           if (input.charCodeAt(peg$currPos) === 34) {
-                            s0 = peg$c30;
+                            s0 = peg$c34;
                             peg$currPos++;
                           } else {
                             s0 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c31); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c35); }
                           }
                           if (s0 === peg$FAILED) {
                             if (input.charCodeAt(peg$currPos) === 63) {
-                              s0 = peg$c55;
+                              s0 = peg$c59;
                               peg$currPos++;
                             } else {
                               s0 = peg$FAILED;
-                              if (peg$silentFails === 0) { peg$fail(peg$c56); }
+                              if (peg$silentFails === 0) { peg$fail(peg$c60); }
                             }
                             if (s0 === peg$FAILED) {
                               if (input.charCodeAt(peg$currPos) === 58) {
-                                s0 = peg$c57;
+                                s0 = peg$c61;
                                 peg$currPos++;
                               } else {
                                 s0 = peg$FAILED;
-                                if (peg$silentFails === 0) { peg$fail(peg$c58); }
+                                if (peg$silentFails === 0) { peg$fail(peg$c62); }
                               }
                               if (s0 === peg$FAILED) {
                                 if (input.charCodeAt(peg$currPos) === 92) {
-                                  s0 = peg$c34;
+                                  s0 = peg$c38;
                                   peg$currPos++;
                                 } else {
                                   s0 = peg$FAILED;
-                                  if (peg$silentFails === 0) { peg$fail(peg$c35); }
+                                  if (peg$silentFails === 0) { peg$fail(peg$c39); }
                                 }
                                 if (s0 === peg$FAILED) {
                                   if (input.charCodeAt(peg$currPos) === 38) {
-                                    s0 = peg$c59;
+                                    s0 = peg$c63;
                                     peg$currPos++;
                                   } else {
                                     s0 = peg$FAILED;
-                                    if (peg$silentFails === 0) { peg$fail(peg$c60); }
+                                    if (peg$silentFails === 0) { peg$fail(peg$c64); }
                                   }
                                   if (s0 === peg$FAILED) {
                                     if (input.charCodeAt(peg$currPos) === 124) {
-                                      s0 = peg$c61;
+                                      s0 = peg$c65;
                                       peg$currPos++;
                                     } else {
                                       s0 = peg$FAILED;
-                                      if (peg$silentFails === 0) { peg$fail(peg$c62); }
+                                      if (peg$silentFails === 0) { peg$fail(peg$c66); }
                                     }
                                     if (s0 === peg$FAILED) {
                                       if (input.charCodeAt(peg$currPos) === 39) {
-                                        s0 = peg$c63;
+                                        s0 = peg$c67;
                                         peg$currPos++;
                                       } else {
                                         s0 = peg$FAILED;
-                                        if (peg$silentFails === 0) { peg$fail(peg$c64); }
+                                        if (peg$silentFails === 0) { peg$fail(peg$c68); }
                                       }
                                       if (s0 === peg$FAILED) {
                                         if (input.charCodeAt(peg$currPos) === 47) {
-                                          s0 = peg$c65;
+                                          s0 = peg$c69;
                                           peg$currPos++;
                                         } else {
                                           s0 = peg$FAILED;
-                                          if (peg$silentFails === 0) { peg$fail(peg$c66); }
+                                          if (peg$silentFails === 0) { peg$fail(peg$c70); }
                                         }
                                       }
                                     }
@@ -1306,17 +1492,17 @@ module.exports = (function() {
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 126) {
-        s1 = peg$c67;
+        s1 = peg$c71;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c68); }
+        if (peg$silentFails === 0) { peg$fail(peg$c72); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseint_exp();
         if (s2 !== peg$FAILED) {
           peg$reportedPos = s0;
-          s1 = peg$c69(s2);
+          s1 = peg$c73(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -1335,17 +1521,17 @@ module.exports = (function() {
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 94) {
-        s1 = peg$c53;
+        s1 = peg$c57;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c54); }
+        if (peg$silentFails === 0) { peg$fail(peg$c58); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parsedecimal_or_int_exp();
         if (s2 !== peg$FAILED) {
           peg$reportedPos = s0;
-          s1 = peg$c70(s2);
+          s1 = peg$c74(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -1364,20 +1550,20 @@ module.exports = (function() {
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 126) {
-        s1 = peg$c67;
+        s1 = peg$c71;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c68); }
+        if (peg$silentFails === 0) { peg$fail(peg$c72); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parsedecimal_exp();
         if (s2 === peg$FAILED) {
-          s2 = peg$c14;
+          s2 = peg$c15;
         }
         if (s2 !== peg$FAILED) {
           peg$reportedPos = s0;
-          s1 = peg$c71(s2);
+          s1 = peg$c75(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -1406,31 +1592,31 @@ module.exports = (function() {
       var s0, s1, s2, s3;
 
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 2) === peg$c72) {
-        s1 = peg$c72;
+      if (input.substr(peg$currPos, 2) === peg$c76) {
+        s1 = peg$c76;
         peg$currPos += 2;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c73); }
+        if (peg$silentFails === 0) { peg$fail(peg$c77); }
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
-        if (peg$c74.test(input.charAt(peg$currPos))) {
+        if (peg$c78.test(input.charAt(peg$currPos))) {
           s3 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c75); }
+          if (peg$silentFails === 0) { peg$fail(peg$c79); }
         }
         if (s3 !== peg$FAILED) {
           while (s3 !== peg$FAILED) {
             s2.push(s3);
-            if (peg$c74.test(input.charAt(peg$currPos))) {
+            if (peg$c78.test(input.charAt(peg$currPos))) {
               s3 = input.charAt(peg$currPos);
               peg$currPos++;
             } else {
               s3 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c75); }
+              if (peg$silentFails === 0) { peg$fail(peg$c79); }
             }
           }
         } else {
@@ -1438,7 +1624,7 @@ module.exports = (function() {
         }
         if (s2 !== peg$FAILED) {
           peg$reportedPos = s0;
-          s1 = peg$c76(s2);
+          s1 = peg$c80(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -1457,22 +1643,22 @@ module.exports = (function() {
 
       s0 = peg$currPos;
       s1 = [];
-      if (peg$c74.test(input.charAt(peg$currPos))) {
+      if (peg$c78.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c75); }
+        if (peg$silentFails === 0) { peg$fail(peg$c79); }
       }
       if (s2 !== peg$FAILED) {
         while (s2 !== peg$FAILED) {
           s1.push(s2);
-          if (peg$c74.test(input.charAt(peg$currPos))) {
+          if (peg$c78.test(input.charAt(peg$currPos))) {
             s2 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c75); }
+            if (peg$silentFails === 0) { peg$fail(peg$c79); }
           }
         }
       } else {
@@ -1480,7 +1666,7 @@ module.exports = (function() {
       }
       if (s1 !== peg$FAILED) {
         peg$reportedPos = s0;
-        s1 = peg$c77(s1);
+        s1 = peg$c81(s1);
       }
       s0 = s1;
 
@@ -1492,11 +1678,11 @@ module.exports = (function() {
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 91) {
-        s1 = peg$c49;
+        s1 = peg$c53;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c50); }
+        if (peg$silentFails === 0) { peg$fail(peg$c54); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseranged_term();
@@ -1508,12 +1694,12 @@ module.exports = (function() {
             s4 = peg$parse_();
           }
           if (s3 !== peg$FAILED) {
-            if (input.substr(peg$currPos, 2) === peg$c78) {
-              s4 = peg$c78;
+            if (input.substr(peg$currPos, 2) === peg$c82) {
+              s4 = peg$c82;
               peg$currPos += 2;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c79); }
+              if (peg$silentFails === 0) { peg$fail(peg$c83); }
             }
             if (s4 !== peg$FAILED) {
               s5 = [];
@@ -1530,15 +1716,15 @@ module.exports = (function() {
                 s6 = peg$parseranged_term();
                 if (s6 !== peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 93) {
-                    s7 = peg$c51;
+                    s7 = peg$c55;
                     peg$currPos++;
                   } else {
                     s7 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c52); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c56); }
                   }
                   if (s7 !== peg$FAILED) {
                     peg$reportedPos = s0;
-                    s1 = peg$c80(s2, s6);
+                    s1 = peg$c84(s2, s6);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -1571,11 +1757,11 @@ module.exports = (function() {
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 123) {
-          s1 = peg$c45;
+          s1 = peg$c49;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c46); }
+          if (peg$silentFails === 0) { peg$fail(peg$c50); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parseranged_term();
@@ -1587,12 +1773,12 @@ module.exports = (function() {
               s4 = peg$parse_();
             }
             if (s3 !== peg$FAILED) {
-              if (input.substr(peg$currPos, 2) === peg$c78) {
-                s4 = peg$c78;
+              if (input.substr(peg$currPos, 2) === peg$c82) {
+                s4 = peg$c82;
                 peg$currPos += 2;
               } else {
                 s4 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c79); }
+                if (peg$silentFails === 0) { peg$fail(peg$c83); }
               }
               if (s4 !== peg$FAILED) {
                 s5 = [];
@@ -1609,15 +1795,15 @@ module.exports = (function() {
                   s6 = peg$parseranged_term();
                   if (s6 !== peg$FAILED) {
                     if (input.charCodeAt(peg$currPos) === 125) {
-                      s7 = peg$c47;
+                      s7 = peg$c51;
                       peg$currPos++;
                     } else {
                       s7 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c48); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c52); }
                     }
                     if (s7 !== peg$FAILED) {
                       peg$reportedPos = s0;
-                      s1 = peg$c81(s2, s6);
+                      s1 = peg$c85(s2, s6);
                       s0 = s1;
                     } else {
                       peg$currPos = s0;
@@ -1650,11 +1836,11 @@ module.exports = (function() {
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 91) {
-            s1 = peg$c49;
+            s1 = peg$c53;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c50); }
+            if (peg$silentFails === 0) { peg$fail(peg$c54); }
           }
           if (s1 !== peg$FAILED) {
             s2 = peg$parseranged_term();
@@ -1666,12 +1852,12 @@ module.exports = (function() {
                 s4 = peg$parse_();
               }
               if (s3 !== peg$FAILED) {
-                if (input.substr(peg$currPos, 2) === peg$c78) {
-                  s4 = peg$c78;
+                if (input.substr(peg$currPos, 2) === peg$c82) {
+                  s4 = peg$c82;
                   peg$currPos += 2;
                 } else {
                   s4 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c79); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c83); }
                 }
                 if (s4 !== peg$FAILED) {
                   s5 = [];
@@ -1688,15 +1874,15 @@ module.exports = (function() {
                     s6 = peg$parseranged_term();
                     if (s6 !== peg$FAILED) {
                       if (input.charCodeAt(peg$currPos) === 125) {
-                        s7 = peg$c47;
+                        s7 = peg$c51;
                         peg$currPos++;
                       } else {
                         s7 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c48); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c52); }
                       }
                       if (s7 !== peg$FAILED) {
                         peg$reportedPos = s0;
-                        s1 = peg$c82(s2, s6);
+                        s1 = peg$c86(s2, s6);
                         s0 = s1;
                       } else {
                         peg$currPos = s0;
@@ -1729,11 +1915,11 @@ module.exports = (function() {
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
             if (input.charCodeAt(peg$currPos) === 123) {
-              s1 = peg$c45;
+              s1 = peg$c49;
               peg$currPos++;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c46); }
+              if (peg$silentFails === 0) { peg$fail(peg$c50); }
             }
             if (s1 !== peg$FAILED) {
               s2 = peg$parseranged_term();
@@ -1745,12 +1931,12 @@ module.exports = (function() {
                   s4 = peg$parse_();
                 }
                 if (s3 !== peg$FAILED) {
-                  if (input.substr(peg$currPos, 2) === peg$c78) {
-                    s4 = peg$c78;
+                  if (input.substr(peg$currPos, 2) === peg$c82) {
+                    s4 = peg$c82;
                     peg$currPos += 2;
                   } else {
                     s4 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c79); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c83); }
                   }
                   if (s4 !== peg$FAILED) {
                     s5 = [];
@@ -1767,15 +1953,15 @@ module.exports = (function() {
                       s6 = peg$parseranged_term();
                       if (s6 !== peg$FAILED) {
                         if (input.charCodeAt(peg$currPos) === 93) {
-                          s7 = peg$c51;
+                          s7 = peg$c55;
                           peg$currPos++;
                         } else {
                           s7 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c52); }
+                          if (peg$silentFails === 0) { peg$fail(peg$c56); }
                         }
                         if (s7 !== peg$FAILED) {
                           peg$reportedPos = s0;
-                          s1 = peg$c83(s2, s6);
+                          s1 = peg$c87(s2, s6);
                           s0 = s1;
                         } else {
                           peg$currPos = s0;
@@ -1837,7 +2023,7 @@ module.exports = (function() {
           }
           if (s3 !== peg$FAILED) {
             peg$reportedPos = s0;
-            s1 = peg$c84(s2);
+            s1 = peg$c88(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -1865,7 +2051,7 @@ module.exports = (function() {
             s3 = peg$parseEOF();
             if (s3 !== peg$FAILED) {
               peg$reportedPos = s0;
-              s1 = peg$c84(s2);
+              s1 = peg$c88(s2);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -1887,68 +2073,68 @@ module.exports = (function() {
     function peg$parseoperator() {
       var s0;
 
-      if (input.substr(peg$currPos, 6) === peg$c85) {
-        s0 = peg$c85;
+      if (input.substr(peg$currPos, 6) === peg$c89) {
+        s0 = peg$c89;
         peg$currPos += 6;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c86); }
+        if (peg$silentFails === 0) { peg$fail(peg$c90); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 7) === peg$c87) {
-          s0 = peg$c87;
+        if (input.substr(peg$currPos, 7) === peg$c91) {
+          s0 = peg$c91;
           peg$currPos += 7;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c88); }
+          if (peg$silentFails === 0) { peg$fail(peg$c92); }
         }
         if (s0 === peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c89) {
-            s0 = peg$c89;
+          if (input.substr(peg$currPos, 2) === peg$c93) {
+            s0 = peg$c93;
             peg$currPos += 2;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c90); }
+            if (peg$silentFails === 0) { peg$fail(peg$c94); }
           }
           if (s0 === peg$FAILED) {
-            if (input.substr(peg$currPos, 3) === peg$c91) {
-              s0 = peg$c91;
+            if (input.substr(peg$currPos, 3) === peg$c95) {
+              s0 = peg$c95;
               peg$currPos += 3;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c92); }
+              if (peg$silentFails === 0) { peg$fail(peg$c96); }
             }
             if (s0 === peg$FAILED) {
-              if (input.substr(peg$currPos, 3) === peg$c93) {
-                s0 = peg$c93;
+              if (input.substr(peg$currPos, 3) === peg$c97) {
+                s0 = peg$c97;
                 peg$currPos += 3;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c94); }
+                if (peg$silentFails === 0) { peg$fail(peg$c98); }
               }
               if (s0 === peg$FAILED) {
-                if (input.substr(peg$currPos, 2) === peg$c95) {
-                  s0 = peg$c95;
+                if (input.substr(peg$currPos, 2) === peg$c99) {
+                  s0 = peg$c99;
                   peg$currPos += 2;
                 } else {
                   s0 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c96); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c100); }
                 }
                 if (s0 === peg$FAILED) {
-                  if (input.substr(peg$currPos, 2) === peg$c97) {
-                    s0 = peg$c97;
+                  if (input.substr(peg$currPos, 2) === peg$c101) {
+                    s0 = peg$c101;
                     peg$currPos += 2;
                   } else {
                     s0 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c98); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c102); }
                   }
                   if (s0 === peg$FAILED) {
                     if (input.charCodeAt(peg$currPos) === 33) {
-                      s0 = peg$c43;
+                      s0 = peg$c47;
                       peg$currPos++;
                     } else {
                       s0 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c44); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c48); }
                     }
                   }
                 }
@@ -1975,7 +2161,7 @@ module.exports = (function() {
         s2 = peg$parseprefix_operator();
         if (s2 !== peg$FAILED) {
           peg$reportedPos = s0;
-          s1 = peg$c84(s2);
+          s1 = peg$c88(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -1993,19 +2179,19 @@ module.exports = (function() {
       var s0;
 
       if (input.charCodeAt(peg$currPos) === 43) {
-        s0 = peg$c39;
+        s0 = peg$c43;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c40); }
+        if (peg$silentFails === 0) { peg$fail(peg$c44); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 45) {
-          s0 = peg$c41;
+          s0 = peg$c45;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c42); }
+          if (peg$silentFails === 0) { peg$fail(peg$c46); }
         }
       }
 
@@ -2017,22 +2203,22 @@ module.exports = (function() {
 
       peg$silentFails++;
       s0 = [];
-      if (peg$c100.test(input.charAt(peg$currPos))) {
+      if (peg$c104.test(input.charAt(peg$currPos))) {
         s1 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c101); }
+        if (peg$silentFails === 0) { peg$fail(peg$c105); }
       }
       if (s1 !== peg$FAILED) {
         while (s1 !== peg$FAILED) {
           s0.push(s1);
-          if (peg$c100.test(input.charAt(peg$currPos))) {
+          if (peg$c104.test(input.charAt(peg$currPos))) {
             s1 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c101); }
+            if (peg$silentFails === 0) { peg$fail(peg$c105); }
           }
         }
       } else {
@@ -2041,7 +2227,7 @@ module.exports = (function() {
       peg$silentFails--;
       if (s0 === peg$FAILED) {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c99); }
+        if (peg$silentFails === 0) { peg$fail(peg$c103); }
       }
 
       return s0;
@@ -2057,11 +2243,11 @@ module.exports = (function() {
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c36); }
+        if (peg$silentFails === 0) { peg$fail(peg$c40); }
       }
       peg$silentFails--;
       if (s1 === peg$FAILED) {
-        s0 = peg$c33;
+        s0 = peg$c37;
       } else {
         peg$currPos = s0;
         s0 = peg$c0;


### PR DESCRIPTION
Allows for prefixes to be optionally parsed previous to a group expression.

Example:
`-foo:[bar TO baz]` is parsed as 
```
{
   "left": {
      "term_min": "bar",
      "term_max": "baz",
      "inclusive": "both",
      "field": "foo",
      "group_prefix": "-"
   }
}
```